### PR TITLE
Lazy open files with cache

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -79,6 +79,8 @@ setup(
         "pytest==6.0.1",
         "pybenzinaparse @ git+https://github.com/satyaog/pybenzinaparse.git@653e71586726ed04293d7362e3539e26dc28850c#egg=pybenzinaparse-0.2.1",
     ],
+    extras_require={"psnrhma": ["opencv-python",
+                                "scipy"]},
     packages             = find_packages("src"),
     package_dir          = {'': 'src'},
     ext_modules          = [

--- a/src/benzina/torch/dataloader.py
+++ b/src/benzina/torch/dataloader.py
@@ -9,8 +9,6 @@ from   torch.utils.data.dataloader import default_collate
 from   contextlib                  import suppress
 from   .                           import operations as ops
 
-from   benzina.utils.file import Track
-
 
 class DataLoader(torch.utils.data.DataLoader):
     """
@@ -258,8 +256,7 @@ class _DataLoaderIter:
         indices     = [int(i)                     for i in indices]
         ptrs        = [int(buffer[n].data_ptr())  for n in range(len(indices))]
         samples     = [self.dataset[i]            for i in indices]
-        items, auxd = zip(*[(Track(item.input.as_file(), item.input_label), item.target)
-                            for item in samples])
+        items, auxd = zip(*[(sample.input, sample.aux) for sample in samples])
         token       = (buffer, self.collate_fn(auxd))
         t_args      = (self.shape, self.RNG)
 

--- a/src/benzina/torch/dataloader.py
+++ b/src/benzina/torch/dataloader.py
@@ -258,22 +258,24 @@ class _DataLoaderIter:
         indices     = [int(i)                     for i in indices]
         ptrs        = [int(buffer[n].data_ptr())  for n in range(len(indices))]
         samples     = [self.dataset[i]            for i in indices]
-        items, auxd = zip(*[((item.input, item.input_label), item.target) for item in samples])
-        # Use "bzna_thumb" until having a dataloader that is able to load
-        # the size variant images in "bzna_input"
-        inputs      = [Track(item.as_file(), label) for item, label in items]
-        token       = (buffer, *self.collate_fn(auxd))
+        items, auxd = zip(*[(Track(item.input.as_file(), item.input_label), item.target)
+                            for item in samples])
+        token       = (buffer, self.collate_fn(auxd))
         t_args      = (self.shape, self.RNG)
 
+        # Open items outside of the lock
+        for item in items:
+            item.open()
+
         with self.core.batch(token) as batch:
-            for i,ptr,input in zip(indices, ptrs, inputs):
-                with batch.sample(i, ptr, input.sample_location(0),
-                                  input.video_configuration_location()):
-                    self.core.setHomography    (*self.warp_transform (i, input.shape, *t_args))
-                    self.core.selectColorMatrix(*self.color_transform(i, input.shape, *t_args))
-                    self.core.setBias          (*self.bias_transform (i, input.shape, *t_args))
-                    self.core.setScale         (*self.norm_transform (i, input.shape, *t_args))
-                    self.core.setOOBColor      (*self.oob_transform  (i, input.shape, *t_args))
+            for i,ptr,item in zip(indices, ptrs, items):
+                with batch.sample(i, ptr, item.sample_location(0),
+                                  item.video_configuration_location()):
+                    self.core.setHomography    (*self.warp_transform (i, item.shape, *t_args))
+                    self.core.selectColorMatrix(*self.color_transform(i, item.shape, *t_args))
+                    self.core.setBias          (*self.bias_transform (i, item.shape, *t_args))
+                    self.core.setScale         (*self.norm_transform (i, item.shape, *t_args))
+                    self.core.setOOBColor      (*self.oob_transform  (i, item.shape, *t_args))
     
     def pull(self):
         if self.core.pulls >= self.core.pushes:

--- a/src/benzina/torch/dataset.py
+++ b/src/benzina/torch/dataset.py
@@ -14,6 +14,22 @@ _TrackPairType = typing.Tuple[_TrackType, _TrackType]
 _ClassTracksType = typing.Tuple[_TrackType, _TrackType]
 
 
+def default_getter(dataset, getter):
+    del dataset
+    return getter
+
+
+def cached_getter(dataset, getter):
+    cache = None
+
+    def _getter(index: int):
+        nonlocal cache
+        if cache is None:
+            cache = [getter(i) for i in range(len(dataset))]
+        return cache[index]
+    return _getter
+
+
 class Dataset(torch.utils.data.Dataset):
     """
     Args:
@@ -28,7 +44,8 @@ class Dataset(torch.utils.data.Dataset):
 
     def __init__(self,
                  archive: typing.Union[str, _TrackType] = None,
-                 track: _TrackType = "bzna_input"):
+                 track: _TrackType = "bzna_input",
+                 getter=default_getter):
         if isinstance(archive, Track):
             track = archive
             archive = None
@@ -57,6 +74,7 @@ class Dataset(torch.utils.data.Dataset):
             self._track.close()
 
         self._filename = track.file.name
+        self._getitem = getter(self, self._getitem)
 
     @property
     def filename(self):
@@ -66,10 +84,13 @@ class Dataset(torch.utils.data.Dataset):
         return len(self._track)
     
     def __getitem__(self, index: int):
-        return Dataset._Item(self._track[index])
+        return self._getitem(index)
 
     def __add__(self, other):
         raise NotImplementedError()
+
+    def _getitem(self, index: int):
+        return Dataset._Item(input=self._track[index])
 
 
 class ClassificationDataset(Dataset):
@@ -85,12 +106,13 @@ class ClassificationDataset(Dataset):
             track. (default: ``"bzna_thumb"``)
     """
 
-    _Item = namedtuple("Item", ["input", "input_label", "aux"])
+    _Item = namedtuple("Item", ["input", "aux"])
 
     def __init__(self,
                  archive: typing.Union[str, _TrackPairType] = None,
                  tracks: _ClassTracksType = ("bzna_input", "bzna_target"),
-                 input_label: str = "bzna_thumb"):
+                 input_label: str = "bzna_thumb",
+                 getter=default_getter):
         try:
             archive, tracks = \
                 ClassificationDataset._validate_source(None, archive)
@@ -105,7 +127,7 @@ class ClassificationDataset(Dataset):
         else:
             input_track, target_track = tracks
 
-        Dataset.__init__(self, input_track)
+        Dataset.__init__(self, input_track, getter=getter)
 
         self._indices = np.arange(Dataset.__len__(self), dtype=np.int64)
 
@@ -127,18 +149,18 @@ class ClassificationDataset(Dataset):
     def __len__(self):
         return len(self._indices)
 
-    def __getitem__(self, index: int):
-        item = Dataset.__getitem__(self, self._indices[index])
-        return ClassificationDataset._Item(input=item.input,
-                                           input_label=self._input_label,
-                                           aux=self._targets[index])
-
     def __add__(self, other):
         raise NotImplementedError()
 
     @property
     def targets(self):
         return self._targets
+
+    def _getitem(self, index: int):
+        item = Dataset._getitem(self, self._indices[index])
+        return ClassificationDataset._Item(
+            input=Track(item.input.as_file(), self._input_label),
+            aux=self._targets[index])
 
     @staticmethod
     def _validate_source(*args):
@@ -190,7 +212,8 @@ class ImageNet(ClassificationDataset):
                  root: typing.Union[str, _TrackPairType] = None,
                  split: str = None,
                  tracks: _ClassTracksType = ("bzna_input", "bzna_target"),
-                 input_label: str = "bzna_thumb"):
+                 input_label: str = "bzna_thumb",
+                 getter=cached_getter):
         try:
             archive, split, tracks = \
                 ImageNet._validate_source(None, split, root)
@@ -198,7 +221,8 @@ class ImageNet(ClassificationDataset):
             archive, split, tracks = \
                 ImageNet._validate_source(root, split, tracks)
 
-        ClassificationDataset.__init__(self, archive, tracks, input_label)
+        ClassificationDataset.__init__(self, archive, tracks, input_label,
+                                       getter=getter)
 
         if split == "test":
             self._indices = self._indices[-self.LEN_TEST:]

--- a/src/benzina/torch/operations.py
+++ b/src/benzina/torch/operations.py
@@ -464,8 +464,7 @@ class CenterResizedCrop     (SimilarityTransform):
             (default: ``+1.0``)
         keep_ratio (bool, optional): match the smaller edge to the
             corresponding output edge size, keeping the aspect ratio after
-            resize. Has no effect if :attr:`resize` is ``False``.
-            (default: ``False``)
+            resize. (default: ``False``)
     """
     def __init__(self,
                  scale=+1.0,

--- a/src/benzina/utils/__init__.py
+++ b/src/benzina/utils/__init__.py
@@ -1,3 +1,4 @@
 from .     import file
 from .     import mp4
 from .file import File, Track
+from .psnrhma import psnrhma_color

--- a/src/benzina/utils/file.py
+++ b/src/benzina/utils/file.py
@@ -6,66 +6,113 @@ from benzina.utils.mp4 import get_chunk_offset_at, get_name_at, \
     get_sample_size_at, get_shape_at, find_headers_at, \
     find_sample_table_at, find_video_configuration_at
 
+FileDesc = namedtuple("FileDesc", ["name", "mode"])
 Trak = namedtuple("Trak", ["label", "shape", "stbl_pos"])
 
 
-class File:
+class FileReadMixin:
+    def __init__(self, disk_file=None, *_args, **_kwargs):
+        self._file = disk_file
+
+    @property
+    def closed(self):
+        return self._file is None or self._file.closed
+
+    def seek(self, offset):
+        self._file.seek(offset)
+
+    def read(self, size):
+        return self._file.read(size)
+
+
+class FileProxy(FileReadMixin):
+    """ When closed, this proxy can be serialized without problems.
+    """
+    def __init__(self, disk_file, mode="rb"):
+        super().__init__(None, mode=mode)
+        self._name = None
+        self._mode = mode
+
+        if isinstance(disk_file, str):
+            self._name = disk_file
+        else:
+            self._name = disk_file.name
+            self._file = disk_file
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def mode(self):
+        return self._mode
+
+    def open(self):
+        if self.closed:
+            self._file = open(self._name, mode=self._mode)
+
+    def close(self):
+        if not self.closed:
+            self._file.close()
+            self._file = None
+
+
+class File(FileReadMixin):
     def __init__(self, disk_file, offset=0):
-        self._path = None
-        self._disk_file = None
+        super().__init__(disk_file, offset=offset)
+        self._owner = False
         self._offset = offset
         self._traks = None
 
         # If disk_file is a path, ownership of the disk file will be held by
         # this instance
         if isinstance(disk_file, str):
-            self._path = disk_file
-        else:
-            self._disk_file = disk_file
+            self._owner = True
+        if not isinstance(self._file, FileProxy):
+            self._file = FileProxy(disk_file, mode="rb")
+        if not self.closed:
             self._parse()
 
     def __enter__(self):
         # If self._path is set, ownership of the disk file is held by this
         # instance and it will be opened here
-        if self._path:
+        if self._owner:
             self.open()
         return self
 
     def __exit__(self, type, value, traceback):
         # If self._path is set, ownership of the disk file is held by this
         # instance and the file should be closed here
-        if self._path:
+        if self._owner:
             self.close()
 
     @property
-    def path(self):
-        return self._path
+    def name(self):
+        return self._file.name
 
     @property
     def offset(self):
         return self._offset
 
     def open(self):
-        if not self._disk_file or self._disk_file.closed:
-            self._disk_file = open(self._path, "rb")
+        self._file.open()
         if self._traks is None:
             self._parse()
 
     def close(self):
-        if self._disk_file and not self._disk_file.closed:
-            self._disk_file.close()
-            self._disk_file = None
-
-    def seek(self, offset):
-        self._disk_file.seek(offset)
-
-    def read(self, size):
-        return self._disk_file.read(size)
+        self._file.close()
 
     def trak(self, label):
         if self._traks is None:
             raise RuntimeError("File [{}] is missing a moov box"
-                               .format(self._disk_file.name if self._disk_file else self._path))
+                               .format(self._file.name))
 
         if isinstance(label, str):
             label = label.encode("utf-8")
@@ -76,24 +123,24 @@ class File:
         return self._traks.get(label, None)
 
     def subfile(self, offset):
-        return File(self._disk_file, offset=offset)
+        return File(self._file, offset=offset)
 
     def _parse(self):
         self._traks = {}
 
         moov_pos, box_size, _, header_size = \
-            next(find_headers_at(self._disk_file, {b"moov"}, self._offset))
-        self._disk_file.seek(moov_pos)
+            next(find_headers_at(self._file, {b"moov"}, self._offset))
+        self._file.seek(moov_pos)
         for trak_pos, _, _, _ in \
-            find_headers_at(self._disk_file, {b"trak"},
+            find_headers_at(self._file, {b"trak"},
                             moov_pos + header_size, box_size - header_size):
-            trak_label = get_name_at(self._disk_file, trak_pos)
+            trak_label = get_name_at(self._file, trak_pos)
 
             if trak_label[-1] == 0:
                 trak_label = trak_label[:-1]
 
-            trak_shape = get_shape_at(self._disk_file, trak_pos)
-            trak_stbl_pos, _, _, _ = find_sample_table_at(self._disk_file, trak_pos)
+            trak_shape = get_shape_at(self._file, trak_pos)
+            trak_stbl_pos, _, _, _ = find_sample_table_at(self._file, trak_pos)
 
             self._traks[trak_label] = Trak(trak_label,
                                            trak_shape,
@@ -101,7 +148,7 @@ class File:
 
 
 class Track:
-    def __init__(self, file, label):
+    def __init__(self, f, label):
         self._file_path = None
         self._file = None
         self._label = label
@@ -114,17 +161,21 @@ class Track:
         self._sz = np.empty(0, np.uint32)
 
         # If file is a path, ownership of the file will be held by this instance
-        if isinstance(file, str):
-            self._file_path = file
+        if isinstance(f, str):
+            self._file_path = f
+            self._file = File(self._file_path)
         else:
-            self._file = file
-            self._parse()
+            self._file = f
+            if not self._file.closed:
+                self._parse()
 
     def __len__(self):
         return self._len
 
     def __getitem__(self, index):
-        if index >= len(self):
+        if isinstance(index, slice):
+            return [Sample(self, i) for i in range(*index.indices(len(self)))]
+        elif index >= len(self):
             raise IndexError
         return Sample(self, index)
 
@@ -145,16 +196,12 @@ class Track:
             self.close()
 
     def open(self):
-        if not self._file:
-            self._file = File(self._file_path)
         self._file.open()
         if self._trak is None:
             self._parse()
 
     def close(self):
-        if self._file:
-            self._file.close()
-            self._file = None
+        self._file.close()
 
     @property
     def file(self):
@@ -172,6 +219,7 @@ class Track:
         return int(self._file.offset + self._co[index]), int(self._sz[index])
 
     def sample_bytes(self, index):
+        self.open()
         offset, size = self.sample_location(index)
         self._file.seek(offset)
         return self._file.read(size)
@@ -191,26 +239,23 @@ class Track:
         return pos + header_size, box_size - header_size
 
     def _parse(self):
-        self._trak = self._file.trak(self._label)
+        trak = self._file.trak(self._label)
 
         self._co, self._co_buffer = \
-            get_chunk_offset_at(self._file, self._trak.stbl_pos)
-
+            get_chunk_offset_at(self._file, trak.stbl_pos)
         self._sz, self._sz_buffer = \
-            get_sample_size_at(self._file, self._trak.stbl_pos)
+            get_sample_size_at(self._file, trak.stbl_pos)
 
-        if self._sz_buffer is None:
-            self._sz: int
-            self._sz = np.full(len(self._co), self._sz, np.uint32)
+        self._co, self._sz =  np.broadcast_arrays(self._co, self._sz)
 
         self._len = len(self._co)
+        self._trak = trak
 
 
 class Sample:
     def __init__(self, track, index):
         self._track = track
         self._index = index
-        pass
 
     def __bytes__(self):
         return self._track.sample_bytes(self._index)

--- a/src/benzina/utils/mp4.py
+++ b/src/benzina/utils/mp4.py
@@ -141,12 +141,11 @@ def get_sample_size_at(file, stbl_pos=None):
     stsz_buf = file.read(box_size)
     sample_size = int.from_bytes(stsz_buf[header_size:header_size + 4], "big")
     if sample_size > 0:
-        sz_buf = None
-        sz = sample_size
+        sz_buf = stsz_buf[header_size:header_size + 4]
     else:
         sz_buf = stsz_buf[header_size +
                           4 +   # sample_size: uint32
                           4:]   # sample_count: uint32
-        sz = np.frombuffer(sz_buf, np.dtype(">u4"))
+    sz = np.frombuffer(sz_buf, np.dtype(">u4"))
 
     return sz, sz_buf

--- a/src/benzina/utils/psnrhma.py
+++ b/src/benzina/utils/psnrhma.py
@@ -2,9 +2,18 @@
 # -*- coding: utf-8 -*-
 
 # Imports
-import cv2           as cv
-import numpy         as np
-import scipy.fftpack
+import importlib.util
+
+import numpy as np
+
+cv2_spec = importlib.util.find_spec("cv2")
+is_cv2_installed = cv2_spec is not None
+if is_cv2_installed:
+    import cv2 as cv
+scipy_spec = importlib.util.find_spec("scipy")
+is_scipy_installed = scipy_spec is not None
+if is_scipy_installed:
+    import scipy.fftpack
 
 
 #


### PR DESCRIPTION
As files can't be serialized, they need to be open after the serialization of the objects in a multiprocesses environment.

Supersedes #29